### PR TITLE
Add codex instructions for generator

### DIFF
--- a/codex.md
+++ b/codex.md
@@ -1,0 +1,17 @@
+# Codex Instructions
+
+This repository contains the full RavenDB solution. For tasks within this environment, focus on the `Generator` project.
+
+- Build only the `src/Generator` project and its tests.
+- Do **not** build or test the rest of the solution.
+- The other projects are provided for reference only.
+
+## Build & Test
+
+```sh
+dotnet build src/Generator/Generator.csproj
+
+dotnet test test/Generator.Tests/Generator.Tests.csproj
+```
+
+Only run the tests found under `Generator.Tests`.


### PR DESCRIPTION
## Summary
- add `codex.md` describing that only the Generator project and its tests should be built and tested

## Testing
- `dotnet build src/Generator/Generator.csproj -c Release`
- `dotnet test test/Generator.Tests/Generator.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686d7a2a26c88328999da17fbfb754f5