### PR TITLE
Add hosting and logging to generator project

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -143,7 +143,11 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions" Version="22.0.15" />
+    <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.15" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="XunitLogger" Version="4.0.991" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
-    <PackageVersion Include="ZstdSharp.Port" Version="0.8.5" />
-  </ItemGroup></Project>
+    <PackageVersion Include="ZstdSharp.Port" Version="0.8.5" />  </ItemGroup></Project>

--- a/src/Generator/Generator.csproj
+++ b/src/Generator/Generator.csproj
@@ -3,8 +3,19 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="TestableIO.System.IO.Abstractions" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Hosting" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/Generator/PlaceholderService.cs
+++ b/src/Generator/PlaceholderService.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.IO.Abstractions;
+
+public class PlaceholderService : BackgroundService
+{
+    private readonly ILogger<PlaceholderService> _logger;
+    private readonly TimeProvider _timeProvider;
+    private readonly IFileSystem _fileSystem;
+
+    public PlaceholderService(ILogger<PlaceholderService> logger, TimeProvider timeProvider, IFileSystem fileSystem)
+    {
+        _logger = logger;
+        _timeProvider = timeProvider;
+        _fileSystem = fileSystem;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Service running at {Time}", _timeProvider.GetUtcNow());
+            await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+        }
+    }
+}

--- a/src/Generator/Program.cs
+++ b/src/Generator/Program.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using Generator;
+using System.IO.Abstractions;
+
+IHost host = Host.CreateDefaultBuilder(args)
+    .UseSerilog((context, services, configuration) =>
+        configuration.WriteTo.Console())
+    .ConfigureServices((context, services) =>
+    {
+        services.AddSingleton<IFileSystem, FileSystem>();
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton<FileGenerator>();
+        services.AddHostedService<PlaceholderService>();
+    })
+    .Build();
+
+await host.RunAsync();

--- a/src/Generator/appsettings.json
+++ b/src/Generator/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Serilog": {
+    "MinimumLevel": "Information",
+    "WriteTo": [
+      { "Name": "Console" }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- hook up Microsoft.Extensions.Hosting to `Generator` project
- register Serilog and dependency services
- implement a placeholder background service
- provide default Serilog console config in appsettings
- include package versions for Serilog and hosting dependencies

## Testing
- `dotnet build src/Generator/Generator.csproj -c Release -v minimal`
- `dotnet build test/Generator.Tests/Generator.Tests.csproj -c Release -v minimal`
- `dotnet test test/Generator.Tests/Generator.Tests.csproj --no-build -c Release -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_686d7cdc15f08328b506a433ad1bdbd5